### PR TITLE
fix a crash bug when networking is down

### DIFF
--- a/networkutils/resolvehostname.cpp
+++ b/networkutils/resolvehostname.cpp
@@ -55,7 +55,9 @@ HRESULT ResolveHostName(const char* pszHostName, int family, bool fNumericOnly, 
     
 Cleanup:
 
-    ::freeaddrinfo(pResultList);
+    if (pResultList != NULL) {
+        ::freeaddrinfo(pResultList);
+    }
 
     return hr;
 


### PR DESCRIPTION
When networking is down, getaddrinfo will fail leaving pResultList untouched. Calling freeaddrinfo on NULL will result in segment fault.