### PR TITLE
Compile fixes/warnings from Mac OS X

### DIFF
--- a/networkutils/polling.cpp
+++ b/networkutils/polling.cpp
@@ -18,7 +18,7 @@
 #include "polling.h"
 #include "fasthash.h"
 
-#ifdef __GNUC__
+#ifdef IS_LINUX
     #ifndef HAS_EPOLL
     #pragma message "polling.cpp: WARNING - EPOLL IS NOT AVAILABLE"
     #endif

--- a/server/Makefile
+++ b/server/Makefile
@@ -3,7 +3,7 @@ include ../common.inc
 PROJECT_TARGET := stunserver
 PROJECT_OBJS := main.o server.o stunconnection.o stunsocketthread.o tcpserver.o
 
-INCLUDES := $(BOOST_INCLUDE) -I../common -I../stuncore -I../networkutils -I../resources
+INCLUDES := $(BOOST_INCLUDE) $(OPENSSL_INCLUDE) -I../common -I../stuncore -I../networkutils -I../resources
 LIB_PATH := -L../common -L../stuncore -L../networkutils
 LIBS := -lnetworkutils -lstuncore -lcommon -pthread -lcrypto
 

--- a/stuncore/datastream.cpp
+++ b/stuncore/datastream.cpp
@@ -191,7 +191,7 @@ HRESULT CDataStream::SeekDirect(size_t pos)
 
     // seeking is allowed anywhere between 0 and stream size
 
-    if ((pos >= 0) && (pos <= currentSize))
+    if (pos <= currentSize)
     {
         _pos = pos;
     }

--- a/testcode/testclientlogic.h
+++ b/testcode/testclientlogic.h
@@ -45,9 +45,6 @@ private:
     
     TransportAddressSet _tsa;
     
-    NatBehavior _behavior;
-    NatFiltering _filtering;
-    
     
     boost::shared_ptr<CStunClientLogic> _spClientLogic;
     

--- a/testcode/testreader.cpp
+++ b/testcode/testreader.cpp
@@ -62,8 +62,6 @@ HRESULT CTestReader::Test1()
     HRESULT hr = S_OK;
 
     StunAttribute attrib;
-    const char* pszExpectedSoftwareAttribute = "STUN test client";
-    const char* pszExpectedUserName = "evtj:h6vY";
     CRefCountedBuffer spBuffer;
     char szStringValue[100];
     
@@ -92,17 +90,17 @@ HRESULT CTestReader::Test1()
 
     ChkIfA(attrib.attributeType != STUN_ATTRIBUTE_SOFTWARE, E_FAIL);
 
-    ChkIfA(0 != ::strncmp(pszExpectedSoftwareAttribute, (const char*)(spBuffer->GetData() + attrib.offset), attrib.size), E_FAIL);
+    ChkIfA(0 != ::strncmp(c_software, (const char*)(spBuffer->GetData() + attrib.offset), attrib.size), E_FAIL);
 
     ChkA(reader.GetAttributeByType(STUN_ATTRIBUTE_USERNAME, &attrib));
 
     ChkIfA(attrib.attributeType != STUN_ATTRIBUTE_USERNAME, E_FAIL);
 
-    ChkIfA(0 != ::strncmp(pszExpectedUserName, (const char*)(spBuffer->GetData() + attrib.offset), attrib.size), E_FAIL);
+    ChkIfA(0 != ::strncmp(c_username, (const char*)(spBuffer->GetData() + attrib.offset), attrib.size), E_FAIL);
     
     
     ChkA(reader.GetStringAttributeByType(STUN_ATTRIBUTE_SOFTWARE, szStringValue, ARRAYSIZE(szStringValue)));
-    ChkIfA(0 != ::strcmp(pszExpectedSoftwareAttribute, szStringValue), E_FAIL);
+    ChkIfA(0 != ::strcmp(c_software, szStringValue), E_FAIL);
 
     ChkIfA(reader.HasFingerprintAttribute() == false, E_FAIL);
 


### PR DESCRIPTION
Fixes some warnings shown by clang on Mac OS X, and adds a missing OPENSSL_INCLUDE.

The missing OPENSSL_INCLUDE is due to Xcode 7 no longer shipping OpenSSL headers on the Mac. Previously this would have compiled if those headers could be found implicitly, now it will only compile if OPENSSL_INCLUDE is both defined in common.inc and used by each Makefile that needs it.