### PR TITLE
Avoid using APIs deprecated in OpenSSL 3.0

### DIFF
--- a/stuncore/stunbuilder.cpp
+++ b/stuncore/stunbuilder.cpp
@@ -570,10 +570,15 @@ HRESULT CStunMessageBuilder::AddMessageIntegrityLongTerm(const char* pszUserName
     
     ASSERT(key+lenTotal == pDst);
 
-#ifndef __APPLE__
+#ifdef __APPLE__
+    pResult = CC_MD5(key, lenTotal, hash);
+#elif OPENSSL_VERSION_NUMBER < 0x30000000L
     pResult = MD5(key, lenTotal, hash);
 #else
-    pResult = CC_MD5(key, lenTotal, hash);
+    if (EVP_Digest(key, lenTotal, hash, NULL, EVP_md5(), NULL))
+    {
+        pResult = hash;
+    }
 #endif
     
     ASSERT(pResult != NULL);


### PR DESCRIPTION
This PR fixes OpenSSL 3.0 API deprecation warnings (or errors, if OpenSSL 3.0 was compiled without deprecated APIs). Most of the API changes were trivial 1:1 replacements, but the EVP MAC API is a little more complex than the old HMAC API was.

In this change, I also reordered the `__APPLE__` checks to avoid creating a mess of nested `#ifs`.

Verified `teststuncode` is passing with both OpenSSL 3.0 and OpenSSL 1.1.1.